### PR TITLE
Add support for 16 streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, adding:
 Will play path/to/placeholder/videostream.mpd in the extra divs.
 If no `placeholder` is defined, these divs' `display` attribute will be set to `none`, effectively hiding them.
 
-To toggle audio on or off click on the viewport that you want to listen to. A green border indicates for which viewport the audio is enabled. You can also use the keyboard keys 1-8.
+To toggle audio on or off click on the viewport that you want to listen to. A green border indicates for which viewport the audio is enabled. You can also use the keyboard keys 1-8 to control the first eight viewports.
 
 ## Keyboard Shortcuts
 - SPACE - toggle play / pause for all viewports

--- a/config/example16.json
+++ b/config/example16.json
@@ -1,0 +1,74 @@
+{
+  "row0": [
+    { "title": "Example 1",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 2",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 3",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 4",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    }
+ ],
+  "row1": [
+    { "title": "Example 5",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 6",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 7",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 8",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    }
+  ],
+  "row2": [
+    { "title": "Example 9",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 10",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 11",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    },
+    { "title": "Example 12",
+      "manifest": "https://content.jwplatform.com/manifests/vM7nH0Kl.m3u8",
+      "type": "hls"
+    }
+  ],
+  "row3": [
+    { "title": "Example 13",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 14",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 15",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    },
+    { "title": "Example 16",
+      "manifest": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
+      "type": "dash"
+    }
+  ]
+}

--- a/public/javascripts/viewer.js
+++ b/public/javascripts/viewer.js
@@ -139,10 +139,12 @@ function togglePlayback(videoelem) {
 }
 
 function togglePlaybackOnAllViewPorts() {
-  for(var i=0; i<2; i++) {
+  for(var i=0; i<4; i++) {
     for(var j=0; j<4; j++) {
       var videoelem = document.getElementById('vp'+i+j);
-      togglePlayback(videoelem);
+      if (videoelem) {
+        togglePlayback(videoelem);
+      }
     }
   }
   togglePlayback(document.getElementById('vpleft')); 
@@ -152,12 +154,15 @@ function togglePlaybackOnAllViewPorts() {
 function initMultiView(config) {
   if (config) {
     shaka.polyfill.installAll();
-    initViewPortRow(0, 4, config);
-    initViewPortRow(1, 4, config);
-    if(config['row0'][0]) { 
+    for(var r=0; r<4; r++) {
+      if(config['row'+r]) {
+        initViewPortRow(r, 4, config);
+      }
+    }
+    if(config['row0'] && config['row0'][0]) {
       initViewPort(config['row0'][0], 'vpleft');
     }
-    if(config['row1'][0]) { 
+    if(config['row1'] && config['row1'][0]) {
       initViewPort(config['row1'][0], 'vpright');
     }
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,7 +10,9 @@ const path = require('path');
 function initiateDefaultConf() {
   return {
     "row0": [],
-    "row1": []
+    "row1": [],
+    "row2": [],
+    "row3": []
   };
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,7 +23,7 @@
           <div class="tiny overlay" id="vpright-meta"></div>
           <div id="vpright-title"></div>
         </div>
-        <div><p class="tiny text-center">Click on viewport to activate audio | SPACE - pause/resume | F - toggle fullscreen | 1-8 - activate viewport</p>
+        <div><p class="tiny text-center">Click on viewport to activate audio | SPACE - pause/resume | F - toggle fullscreen | 1-8 - activate viewport (first eight only)</p>
         </div>
         <div id="audioMeter"></div>
       </div>
@@ -79,14 +79,74 @@
           <div class="tiny overlay" id="vp12-meta"></div>
           <div class="title" id="vp12-title"></div>
         </div>
-        <div class="col-md-3 vp" id="vp13-div">
-          <div class="videoInfo tiny"></div>
-          <video id="vp13" class="video-active"></video>
-          <div class="shortcut">8</div>
-          <div class="tiny overlay" id="vp13-meta"></div>
-          <div class="title" id="vp13-title"></div>
-        </div>
+      <div class="col-md-3 vp" id="vp13-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp13" class="video-active"></video>
+        <div class="shortcut">8</div>
+        <div class="tiny overlay" id="vp13-meta"></div>
+        <div class="title" id="vp13-title"></div>
       </div>
+    </div>
+    <div class="row">
+      <div class="col-md-3 vp" id="vp20-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp20" class="video-active"></video>
+        <div class="shortcut">9</div>
+        <div class="tiny overlay" id="vp20-meta"></div>
+        <div class="title" id="vp20-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp21-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp21" class="video-active"></video>
+        <div class="shortcut">10</div>
+        <div class="tiny overlay" id="vp21-meta"></div>
+        <div class="title" id="vp21-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp22-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp22" class="video-active"></video>
+        <div class="shortcut">11</div>
+        <div class="tiny overlay" id="vp22-meta"></div>
+        <div class="title" id="vp22-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp23-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp23" class="video-active"></video>
+        <div class="shortcut">12</div>
+        <div class="tiny overlay" id="vp23-meta"></div>
+        <div class="title" id="vp23-title"></div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-3 vp" id="vp30-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp30" class="video-active"></video>
+        <div class="shortcut">13</div>
+        <div class="tiny overlay" id="vp30-meta"></div>
+        <div class="title" id="vp30-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp31-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp31" class="video-active"></video>
+        <div class="shortcut">14</div>
+        <div class="tiny overlay" id="vp31-meta"></div>
+        <div class="title" id="vp31-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp32-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp32" class="video-active"></video>
+        <div class="shortcut">15</div>
+        <div class="tiny overlay" id="vp32-meta"></div>
+        <div class="title" id="vp32-title"></div>
+      </div>
+      <div class="col-md-3 vp" id="vp33-div">
+        <div class="videoInfo tiny"></div>
+        <video id="vp33" class="video-active"></video>
+        <div class="shortcut">16</div>
+        <div class="tiny overlay" id="vp33-meta"></div>
+        <div class="title" id="vp33-title"></div>
+      </div>
+    </div>
 
     </div>
     <script src="javascripts/hls.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Summary
- extend viewer grid to 16 viewports
- loop over 4 rows in viewer logic
- provide sample config with 16 entries
- clarify keyboard usage in docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c2cf392648324bccbed448ae9ace1