### PR TITLE
Add default playlist logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ REDIRECT_HTTP=true
 When the Node express app is up and running you can direct your Chrome browser to:
 
 > http://localhost:3000/?config=example.json`
-		
-where `example.json` is a configuration file placed in the directory `config/` and can look like this:
+
+where `example.json` is a configuration file placed in the directory `config/`.
+If the `config` parameter is omitted the application will instead look for
+`config/default.json`.
+It can look like this:
 ```json
 {
 	"row0": [

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,15 +18,15 @@ function initiateDefaultConf() {
 
 /* GET home page. */
 router.get('/', function(req, res) {
-  conf = req.query.config;
-  var confobj = initiateDefaultConf();
-  if(conf) {
-    var confpath = '../config/'+conf;
-    console.log("Loading config " + confpath);
-    if (fs.existsSync(path.join(__dirname, confpath))) {
-      var confobj = JSON.parse(fs.readFileSync(path.join(__dirname, confpath), 'utf8'));
-    }
+  let conf = req.query.config || 'default.json';
+  let confobj = initiateDefaultConf();
+
+  const confpath = '../config/' + conf;
+  console.log('Loading config ' + confpath);
+  if (fs.existsSync(path.join(__dirname, confpath))) {
+    confobj = JSON.parse(fs.readFileSync(path.join(__dirname, confpath), 'utf8'));
   }
+
   res.render('index', { title: 'Eyevinn Technology OTT Multiview', conf: JSON.stringify(confobj) });
 });
 


### PR DESCRIPTION
## Summary
- load `config/default.json` when no playlist is specified in the URL
- document default playlist handling in `README`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ffc31bf8c8324900b76a9c522452e