### PR TITLE
Add single stream viewing feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 
 var routes = require('./routes/index');
+var streamRoutes = require('./routes/stream');
 
 var app = express();
 
@@ -26,6 +27,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', routes);
+app.use('/', streamRoutes);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/public/javascripts/viewer.js
+++ b/public/javascripts/viewer.js
@@ -5,6 +5,13 @@
 var activeViewPort;
 var shakaPlayers = {};
 
+function getQueryParameter(name) {
+  name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+  var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+  var results = regex.exec(window.location.search);
+  return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+}
+
 function initHlsPlayer(conf, videoelemid, donecb) {
   var hlsconfig = {
     capLevelToPlayerSize: true
@@ -104,6 +111,11 @@ function initViewPortRow(row, numcols, config) {
     c = config['row'+row][i];
     if (c) {
       initViewPort(c, videoelemid);
+      var linkElem = document.getElementById(videoelemid + '-view-link');
+      if (linkElem) {
+        var cfg = getQueryParameter('config') || 'default.json';
+        linkElem.href = '/stream?config=' + encodeURIComponent(cfg) + '&row=' + row + '&col=' + i;
+      }
     }else if (config['placeholder'] !== undefined &&  config['placeholder'][0] !== undefined){
 	c = config['placeholder'][0];
         initViewPort(c, videoelemid);

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -49,6 +49,7 @@ th {
   min-height: 200px;
   padding: 0px;
   text-align: center;
+  position: relative;
 }
 
 .info {
@@ -87,6 +88,22 @@ video {
 
 .video-unmuted {
   border: 3px solid green;
+}
+
+.view-link {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 20;
+  display: none;
+  padding: 2px 6px;
+  background-color: #000;
+  color: #fff;
+  border: 1px solid #fff;
+}
+
+.vp:hover .view-link {
+  display: block;
 }
 
 .title {

--- a/routes/stream.js
+++ b/routes/stream.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs');
+const path = require('path');
+
+function initiateDefaultConf() {
+  return {
+    "row0": [],
+    "row1": [],
+    "row2": [],
+    "row3": []
+  };
+}
+
+router.get('/stream', function(req, res) {
+  const conffile = req.query.config || 'default.json';
+  const row = parseInt(req.query.row, 10);
+  const col = parseInt(req.query.col, 10);
+
+  const confpath = '../config/' + conffile;
+  let confobj = initiateDefaultConf();
+  if (fs.existsSync(path.join(__dirname, confpath))) {
+    confobj = JSON.parse(fs.readFileSync(path.join(__dirname, confpath), 'utf8'));
+  }
+
+  if (isNaN(row) || isNaN(col) || !confobj['row' + row] || !confobj['row' + row][col]) {
+    res.status(404).send('Stream not found');
+    return;
+  }
+
+  const stream = confobj['row' + row][col];
+  res.render('stream', { title: stream.title, stream });
+});
+
+module.exports = router;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -34,6 +34,7 @@
           <div class="shortcut">1</div>
           <div class="tiny overlay" id="vp00-meta"></div>
           <div class="title" id="vp00-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp00-view-link">View</a>
         </div>
         <div class="col-md-3 vp" id="vp01-div">
           <div class="videoInfo tiny"></div>
@@ -41,6 +42,7 @@
           <div class="shortcut">2</div>
           <div class="tiny overlay" id="vp01-meta"></div>
           <div class="title" id="vp01-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp01-view-link">View</a>
         </div>
         <div class="col-md-3 vp" id="vp02-div">
           <div class="videoInfo tiny"></div>
@@ -48,6 +50,7 @@
           <div class="shortcut">3</div>
           <div class="tiny overlay" id="vp02-meta"></div>
           <div class="title" id="vp02-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp02-view-link">View</a>
         </div>
         <div class="col-md-3 vp" id="vp03-div">
           <div class="videoInfo tiny"></div>
@@ -55,6 +58,7 @@
           <div class="shortcut">4</div>
           <div class="tiny overlay" id="vp03-meta"></div>
           <div class="title" id="vp03-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp03-view-link">View</a>
         </div>
       </div>
       <div class="row">
@@ -64,6 +68,7 @@
           <div class="shortcut">5</div>
           <div class="tiny overlay" id="vp10-meta"></div>
           <div class="title" id="vp10-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp10-view-link">View</a>
         </div>
         <div class="col-md-3 vp" id="vp11-div">
           <div class="videoInfo tiny"></div>
@@ -71,6 +76,7 @@
           <div class="shortcut">6</div>
           <div class="tiny overlay" id="vp11-meta"></div>
           <div class="title" id="vp11-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp11-view-link">View</a>
         </div>
         <div class="col-md-3 vp" id="vp12-div">
           <div class="videoInfo tiny"></div>
@@ -78,6 +84,7 @@
           <div class="shortcut">7</div>
           <div class="tiny overlay" id="vp12-meta"></div>
           <div class="title" id="vp12-title"></div>
+          <a class="view-link btn btn-primary btn-xs" id="vp12-view-link">View</a>
         </div>
       <div class="col-md-3 vp" id="vp13-div">
         <div class="videoInfo tiny"></div>
@@ -85,6 +92,7 @@
         <div class="shortcut">8</div>
         <div class="tiny overlay" id="vp13-meta"></div>
         <div class="title" id="vp13-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp13-view-link">View</a>
       </div>
     </div>
     <div class="row">
@@ -94,6 +102,7 @@
         <div class="shortcut">9</div>
         <div class="tiny overlay" id="vp20-meta"></div>
         <div class="title" id="vp20-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp20-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp21-div">
         <div class="videoInfo tiny"></div>
@@ -101,6 +110,7 @@
         <div class="shortcut">10</div>
         <div class="tiny overlay" id="vp21-meta"></div>
         <div class="title" id="vp21-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp21-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp22-div">
         <div class="videoInfo tiny"></div>
@@ -108,6 +118,7 @@
         <div class="shortcut">11</div>
         <div class="tiny overlay" id="vp22-meta"></div>
         <div class="title" id="vp22-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp22-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp23-div">
         <div class="videoInfo tiny"></div>
@@ -115,6 +126,7 @@
         <div class="shortcut">12</div>
         <div class="tiny overlay" id="vp23-meta"></div>
         <div class="title" id="vp23-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp23-view-link">View</a>
       </div>
     </div>
     <div class="row">
@@ -124,6 +136,7 @@
         <div class="shortcut">13</div>
         <div class="tiny overlay" id="vp30-meta"></div>
         <div class="title" id="vp30-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp30-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp31-div">
         <div class="videoInfo tiny"></div>
@@ -131,6 +144,7 @@
         <div class="shortcut">14</div>
         <div class="tiny overlay" id="vp31-meta"></div>
         <div class="title" id="vp31-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp31-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp32-div">
         <div class="videoInfo tiny"></div>
@@ -138,6 +152,7 @@
         <div class="shortcut">15</div>
         <div class="tiny overlay" id="vp32-meta"></div>
         <div class="title" id="vp32-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp32-view-link">View</a>
       </div>
       <div class="col-md-3 vp" id="vp33-div">
         <div class="videoInfo tiny"></div>
@@ -145,6 +160,7 @@
         <div class="shortcut">16</div>
         <div class="tiny overlay" id="vp33-meta"></div>
         <div class="title" id="vp33-title"></div>
+        <a class="view-link btn btn-primary btn-xs" id="vp33-view-link">View</a>
       </div>
     </div>
 

--- a/views/stream.ejs
+++ b/views/stream.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= title %></title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel='stylesheet' href='/stylesheets/style.css' />
+</head>
+<body>
+  <div class="col-md-8 col-md-offset-2 vp vp-large" id="single-view" style="margin-top:20px;">
+    <div class="videoInfo tiny"></div>
+    <video id="single" class="video-active"></video>
+    <div class="tiny overlay" id="single-meta"></div>
+    <div class="title" id="single-title"></div>
+  </div>
+  <script src="/javascripts/hls.min.js" type="text/javascript"></script>
+  <script src="/javascripts/shaka-player.compiled.js" type="text/javascript"></script>
+  <script src="/javascripts/viewer.js" type="text/javascript"></script>
+  <script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function() {
+      var conf = <%- JSON.stringify(stream) %>;
+      initViewPort(conf, 'single');
+      activateViewPort('single');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create route and view for single stream playback
- add button on each stream tile to open single view
- show button on hover via new CSS
- wire router into Express app
- set button URLs on page load via JavaScript

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68501ff23b988324b00eb2e6f231c988