### PR TITLE
Fix routing for proxy prefix

### DIFF
--- a/public/javascripts/viewer.js
+++ b/public/javascripts/viewer.js
@@ -4,6 +4,10 @@
 // Author: Jonas Birme (Eyevinn Technology)
 var activeViewPort;
 var shakaPlayers = {};
+// Determine base path in case the application is hosted behind a proxy with a
+// path prefix. This removes the trailing file or slash from the current
+// location so that generated links work regardless of where the app is mounted.
+var basePath = window.location.pathname.replace(/\/[^\/]*$/, '');
 
 function getQueryParameter(name) {
   name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
@@ -114,7 +118,9 @@ function initViewPortRow(row, numcols, config) {
       var linkElem = document.getElementById(videoelemid + '-view-link');
       if (linkElem) {
         var cfg = getQueryParameter('config') || 'default.json';
-        linkElem.href = '/stream?config=' + encodeURIComponent(cfg) + '&row=' + row + '&col=' + i;
+        // Use the computed basePath so that the stream links work when the
+        // application is served behind a proxy on a path prefix.
+        linkElem.href = basePath + '/stream?config=' + encodeURIComponent(cfg) + '&row=' + row + '&col=' + i;
       }
     }else if (config['placeholder'] !== undefined &&  config['placeholder'][0] !== undefined){
 	c = config['placeholder'][0];

--- a/views/stream.ejs
+++ b/views/stream.ejs
@@ -3,7 +3,7 @@
 <head>
   <title><%= title %></title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel='stylesheet' href='/stylesheets/style.css' />
+  <link rel='stylesheet' href='../stylesheets/style.css' />
 </head>
 <body>
   <div class="col-md-8 col-md-offset-2 vp vp-large" id="single-view" style="margin-top:20px;">
@@ -12,9 +12,9 @@
     <div class="tiny overlay" id="single-meta"></div>
     <div class="title" id="single-title"></div>
   </div>
-  <script src="/javascripts/hls.min.js" type="text/javascript"></script>
-  <script src="/javascripts/shaka-player.compiled.js" type="text/javascript"></script>
-  <script src="/javascripts/viewer.js" type="text/javascript"></script>
+  <script src="../javascripts/hls.min.js" type="text/javascript"></script>
+  <script src="../javascripts/shaka-player.compiled.js" type="text/javascript"></script>
+  <script src="../javascripts/viewer.js" type="text/javascript"></script>
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function() {
       var conf = <%- JSON.stringify(stream) %>;


### PR DESCRIPTION
## Summary
- support reverse proxy deployments by detecting basePath in `viewer.js`
- use relative paths in `stream.ejs`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685117c869c88324879e5520af0fe9b5