### PR TITLE
Fix routing for proxy prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ If you wish to auto redirect from HTTP (TCP 80) to HTTPs, set/export:
 ```
 REDIRECT_HTTP=true
 ```
+If the application is served behind a reverse proxy on a sub path you can set
+the `BASE_PATH` environment variable to that path (e.g. `/mcr`).
+This ensures that static assets and routes are mounted correctly when the
+prefix is preserved by the proxy.
 **Note that you can only start a listener on TCP 80 and 443 as a super user since these are well known port.**
 
 # Usage

--- a/app.js
+++ b/app.js
@@ -14,6 +14,14 @@ var streamRoutes = require('./routes/stream');
 
 var app = express();
 
+// Optional base path used when the application is served behind a reverse proxy
+// on a path prefix. Example: if BASE_PATH=/mcr the app will listen on
+// https://example.com/mcr/.
+var basePath = process.env.BASE_PATH || '';
+if (basePath !== '' && basePath.endsWith('/')) {
+  basePath = basePath.slice(0, -1);
+}
+
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
@@ -24,10 +32,10 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(basePath, express.static(path.join(__dirname, 'public')));
 
-app.use('/', routes);
-app.use('/', streamRoutes);
+app.use(basePath || '/', routes);
+app.use(basePath || '/', streamRoutes);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/public/javascripts/viewer.js
+++ b/public/javascripts/viewer.js
@@ -4,6 +4,10 @@
 // Author: Jonas Birme (Eyevinn Technology)
 var activeViewPort;
 var shakaPlayers = {};
+// Determine base path in case the application is hosted behind a proxy with a
+// path prefix. This removes the trailing file or slash from the current
+// location so that generated links work regardless of where the app is mounted.
+var basePath = window.location.pathname.replace(/\/[^\/]*$/, '');
 
 function getQueryParameter(name) {
   name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
@@ -114,7 +118,9 @@ function initViewPortRow(row, numcols, config) {
       var linkElem = document.getElementById(videoelemid + '-view-link');
       if (linkElem) {
         var cfg = getQueryParameter('config') || 'default.json';
-        linkElem.href = '/stream?config=' + encodeURIComponent(cfg) + '&row=' + row + '&col=' + i;
+        // Use the computed basePath so that the stream links work when the
+        // application is served behind a proxy on a path prefix.
+        linkElem.href = basePath + '/stream?config=' + encodeURIComponent(cfg) + '&row=' + row + '&col=' + i;
       }
     }else if (config['placeholder'] !== undefined &&  config['placeholder'][0] !== undefined){
 	c = config['placeholder'][0];

--- a/views/stream.ejs
+++ b/views/stream.ejs
@@ -3,7 +3,7 @@
 <head>
   <title><%= title %></title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel='stylesheet' href='/stylesheets/style.css' />
+  <link rel='stylesheet' href='../stylesheets/style.css' />
 </head>
 <body>
   <div class="col-md-8 col-md-offset-2 vp vp-large" id="single-view" style="margin-top:20px;">
@@ -12,9 +12,9 @@
     <div class="tiny overlay" id="single-meta"></div>
     <div class="title" id="single-title"></div>
   </div>
-  <script src="/javascripts/hls.min.js" type="text/javascript"></script>
-  <script src="/javascripts/shaka-player.compiled.js" type="text/javascript"></script>
-  <script src="/javascripts/viewer.js" type="text/javascript"></script>
+  <script src="../javascripts/hls.min.js" type="text/javascript"></script>
+  <script src="../javascripts/shaka-player.compiled.js" type="text/javascript"></script>
+  <script src="../javascripts/viewer.js" type="text/javascript"></script>
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function() {
       var conf = <%- JSON.stringify(stream) %>;


### PR DESCRIPTION
## Summary
- support reverse proxy deployments by adding BASE_PATH to server
- document BASE_PATH usage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685117c869c88324879e5520af0fe9b5