### PR TITLE
Set default port to 3939

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Start the Node express app:
 
 # ENV vars
 
-To start a listener on a port other than 3000, set/export the `PORT` ENV var.
+The application listens on port 3939 by default. To run on a different port, set/export the `PORT` environment variable.
 To start a HTTPs server, export:
 ```
 SSL_KEY=/path/to/key
@@ -47,7 +47,7 @@ prefix is preserved by the proxy.
 
 When the Node express app is up and running you can direct your Chrome browser to:
 
-> http://localhost:3000/?config=example.json`
+> http://localhost:3939/?config=example.json`
 
 where `example.json` is a configuration file placed in the directory `config/`.
 If the `config` parameter is omitted the application will instead look for

--- a/bin/www
+++ b/bin/www
@@ -6,7 +6,7 @@ var https = require('https');
 var http = require('http');
 
 
-app.set('port', process.env.PORT || 3000);
+app.set('port', process.env.PORT || 3939);
 
 // If these ENV vars are all set, start Express over HTTPs
 if (process.env.SSL_KEY && process.env.SSL_CRT && process.env.SSL_CA) {


### PR DESCRIPTION
## Summary
- default port to 3939 in the launch script
- document port 3939 in README

## Testing
- `npm start` *(fails: Cannot find module 'debug')*

------
https://chatgpt.com/codex/tasks/task_e_68511ac709fc83248baef2e517cfefbc