### PR TITLE
Fix static asset paths for stream view

### DIFF
--- a/views/stream.ejs
+++ b/views/stream.ejs
@@ -3,7 +3,7 @@
 <head>
   <title><%= title %></title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel='stylesheet' href='../stylesheets/style.css' />
+  <link rel='stylesheet' href='stylesheets/style.css' />
 </head>
 <body>
   <div class="col-md-8 col-md-offset-2 vp vp-large" id="single-view" style="margin-top:20px;">
@@ -12,9 +12,9 @@
     <div class="tiny overlay" id="single-meta"></div>
     <div class="title" id="single-title"></div>
   </div>
-  <script src="../javascripts/hls.min.js" type="text/javascript"></script>
-  <script src="../javascripts/shaka-player.compiled.js" type="text/javascript"></script>
-  <script src="../javascripts/viewer.js" type="text/javascript"></script>
+  <script src="javascripts/hls.min.js" type="text/javascript"></script>
+  <script src="javascripts/shaka-player.compiled.js" type="text/javascript"></script>
+  <script src="javascripts/viewer.js" type="text/javascript"></script>
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function() {
       var conf = <%- JSON.stringify(stream) %>;


### PR DESCRIPTION
## Summary
- serve static assets from current base path in `stream.ejs`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68511ecb76388324ad3c1a646de0a89a